### PR TITLE
Quality of life improvements for MacOS/VSCode developer setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 build/
 dist/
+*.so
+*.a
+__pycache__
+.cache

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.15...3.26)
 project(prototype)
 
 find_package(Arrow REQUIRED)
+find_package(CURL REQUIRED)
 find_package(Python 3.8 COMPONENTS Interpreter Development.Module REQUIRED)
 find_package(nanobind CONFIG REQUIRED)
 
@@ -16,7 +17,7 @@ nanobind_add_module(
 )
 
 # Link against Arrow's shared library
-target_link_libraries(prototype_cpp PRIVATE Arrow::arrow_shared)
+target_link_libraries(prototype_cpp PRIVATE Arrow::arrow_shared CURL::libcurl)
 
 # For formal installations
 install(TARGETS prototype_cpp

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Setup Guide
 
 # System Dependencies
 
+```shell
 sudo apt-get update
 sudo apt-get install -y     \
     python3-dev             \
@@ -15,16 +16,35 @@ sudo apt-get install -y     \
     build-essential         \
     libcurl4-openssl-dev    \
     libarrow-dev            \
+```
+
+Or on MacOS:
+
+```shell
+brew install apache-arrow cmake curl
+```
 
 # Python dependencies
 
+```shell
 pip install      \
     pyarrow      \
     nanobind     \
-    pytest
+    pytest       \
+    scikit-build-core
+```
 
 # Build
-pip3 install -e . -v
+
+```shell
+pip install .
+
+# Or install in such a way that VSCode/clangd gives nice autocomplete
+pip install -e . -v --config-settings=build-dir=build --no-build-isolation
+```
 
 # Run
+
+```shell
 pytest . -svvv
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,11 @@ requires-python = ">=3.8"
 [tool.scikit-build]
 cmake.version = ">=3.15"
 wheel.packages = ["prototype"]
-# Tell scikit-build-core to use development mode properly
-editable.mode = "inplace"
+# May need to enable this to tell scikit-build-core to use a specific development mode
+# editable.mode = "inplace"
 # Make sure the compiled module ends up in the right place
 wheel.install-dir = "prototype"
+
+# Make life easy for developers using VSCode/clangd
+[tool.scikit-build.cmake.define]
+CMAKE_EXPORT_COMPILE_COMMANDS = "ON"


### PR DESCRIPTION
Because I am useless without autocomplete 🙂 

This works because clangd (via VSCode or otherwise) looks for `compile_commands.json` or `build/compile_commands.json` recursing up the directory tree (since `build/` is a common location to put the "CMake build").

I wasn't sure about the editable inplace things...I've never used scikit build core but it seemed to force the build to happen in the source directory, leaving a lot of files for me to clean up (while carefully remembering not to delete actual important files). No shade if you want to keep that in!